### PR TITLE
add pundit and authorizations to art_piece

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ ruby "3.1.2"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.3", ">= 7.0.3.1"
 
+# Pundit for user authorization
+gem "pundit"
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-test (2.0.2)
@@ -286,6 +288,7 @@ DEPENDENCIES
   jsbundling-rails
   pg (~> 1.1)
   puma (~> 5.0)
+  pundit
   rails (~> 7.0.3, >= 7.0.3.1)
   sassc-rails
   selenium-webdriver

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,22 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
+  
+  include Pundit::Authorization
+
+  # Pundit: white-list approach
+  after_action :verify_authorized, except: :index, unless: :skip_pundit?
+  after_action :verify_policy_scoped, only: :index, unless: :skip_pundit?
+
+  # Uncomment when you *really understand* Pundit!
+  # rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  # def user_not_authorized
+  #   flash[:alert] = "You are not authorized to perform this action."
+  #   redirect_to(root_path)
+  # end
+
+  private
+
+  def skip_pundit?
+    devise_controller? || params[:controller] =~ /(^(rails_)?admin)|(^pages$)/
+  end
 end

--- a/app/controllers/art_pieces_controller.rb
+++ b/app/controllers/art_pieces_controller.rb
@@ -1,12 +1,23 @@
 class ArtPiecesController < ApplicationController
-#   before_action :set_art_piece, only: %i[edit update]
+  before_action :set_art_piece, only: %i[ show ]
+  # add edit update and destroy to before_action after actions are created
+
+  def index
+    @art_pieces = policy_scoped(Art_piece)
+  end
+
+  def show
+  end
 
   def new
-    @list = Art_piece.new()
+    @art_piece = Art_piece.new()
+    authorize @art_piece
   end
 
   def create
     @art_piece = Art_piece.new(art_piece_params)
+    @art_piece.user = current_user
+    authorize @art_piece
     if @art_piece.save
       redirect_to art_piece_path(@art_piece), alert: 'Art piece submitted sucessfully'
     else
@@ -15,26 +26,29 @@ class ArtPiecesController < ApplicationController
   end
 
 #   def edit
-    
 #   end
 
 #   def update
-#     @art_piece.update(art_piece_params)
-#     redirect_to art_piece_path(@art_piece)
+#     if @art_piece.update(art_piece_params)
+#       redirect_to art_piece_path(@art_piece)
+#     else
+#       render :edit
 #   end
 
 #   def destroy
-#     redirect_to art_pieces_path, status: :see_other
+#     @art_piece.destroy
+#     redirect_to art_pieces_path, notice: 'Art piece was successfully destroyed.'
 #   end
 
-#   private
+  private
 
-#   def art_piece_params
-#     params.require(:art_piece).permit(:name, :genre,)
-#   end
+  def art_piece_params
+    params.require(:art_piece).permit(:name, :genre, :photos)
+  end
 
-#   def set_art_piece
-#     @list = Art_piece.find(params[:id])
-#   end
+  def set_art_piece
+    @art_piece = Art_piece.find(params[:id])
+    authorize @art_piece
+  end
 
 end

--- a/app/controllers/art_pieces_controller.rb
+++ b/app/controllers/art_pieces_controller.rb
@@ -3,19 +3,19 @@ class ArtPiecesController < ApplicationController
   # add edit update and destroy to before_action after actions are created
 
   def index
-    @art_pieces = policy_scoped(Art_piece)
+    @art_pieces = policy_scoped(ArtPiece)
   end
 
   def show
   end
 
   def new
-    @art_piece = Art_piece.new()
+    @art_piece = ArtPiece.new()
     authorize @art_piece
   end
 
   def create
-    @art_piece = Art_piece.new(art_piece_params)
+    @art_piece = ArtPiece.new(art_piece_params)
     @art_piece.user = current_user
     authorize @art_piece
     if @art_piece.save
@@ -47,7 +47,7 @@ class ArtPiecesController < ApplicationController
   end
 
   def set_art_piece
-    @art_piece = Art_piece.find(params[:id])
+    @art_piece = ArtPiece.find(params[:id])
     authorize @art_piece
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: [ :home ] 
+
   def home
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/art_piece_policy.rb
+++ b/app/policies/art_piece_policy.rb
@@ -1,0 +1,29 @@
+class ArtPiecePolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  # Uncomment when the actions in controller are created
+  # If the user is owner of the art_piece, it authorizes the update or to destroy, else sets to false  
+  
+  # def update?
+  #   user == record.user 
+  #   add user admin when created ->    || user.admin                                     
+  # end
+
+  # def destroy?
+ #   user == record.user 
+#   add user admin when created ->    || user.admin     
+  # end
+end

--- a/test/policies/art_piece_policy_test.rb
+++ b/test/policies/art_piece_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ArtPiecePolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
**Actions Created:**
- Added pundit gem (REMINDER TO BUNDLE INSTALL)
- Generated policies
- In pages controller, skip authenticate_user
- Added pundit authorizations in art_piece controller
- Created art_piece policy
- Added authorizations to edit/update/destroy in art_piece controller and respective policy but they are **commented out**

**What was set?**
- Home page skips authorizations
- Anyone can view art pieces
- Any user can create a new art piece
- When an art piece is created it is connected to current_user

**Next steps / What's missing?**
- Test all pages to see if authorization is working correctly
- When creating views, add an error message and/or redirect when the user is not authorized to view the page
- When views are created, hide links for edit/destroy if the user is not the owner of art piece
- Create admin and migrations (if agreed)