### PR TITLE
renamed stimulus from indexform to datefield and applied to both forms

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,4 +3,4 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import "bootstrap"
 
-console.log('hello js')
+console.log('hello js');

--- a/app/javascript/controllers/datefield_controller.js
+++ b/app/javascript/controllers/datefield_controller.js
@@ -1,15 +1,14 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="indexform"
+// Connects to data-controller="datefield"
 export default class extends Controller {
   connect() {
-    console.log('hello from indexform stimulus controller')
+    console.log('hello from datefield stimulus controller')
   }
 
   static targets = ["endDate", "startDate"]
 
   update(event) {
     this.endDateTarget.min = this.startDateTarget.value;
-    console.log("min end date updated")
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,5 +7,5 @@ import { application } from "./application"
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
-import IndexformController from "./indexform_controller"
-application.register("indexform", IndexformController)
+import DatefieldController from "./datefield_controller"
+application.register("datefield", DatefieldController)

--- a/app/views/shared/_booking_form.html.erb
+++ b/app/views/shared/_booking_form.html.erb
@@ -1,7 +1,7 @@
 <div class="container shadow p-3 bg-white text-primary mt-3">
-  <%= simple_form_for(booking, url: @url, method: @verb) do |f| %>
-    <%= f.input :start_date, as: :date, html5: true, input_html: { min: Date.today + 1 } %>
-    <%= f.input :end_date, as: :date, html5: true, input_html: { min: Date.today + 1 } %>
+  <%= simple_form_for(booking, url: @url, method: @verb, data: {controller: "datefield"}) do |f| %>
+    <%= f.input :start_date, as: :date, html5: true, input_html: { min: Date.today + 1, "data-action" => "input->datefield#update", "data-datefield-target" => "startDate"} %>
+    <%= f.input :end_date, as: :date, html5: true, input_html: { min: Date.today + 1, "data-datefield-target" => "endDate"} %>
     <div class="text-end">
       <%= f.submit class: "btn btn-warning text-white" %>
     </div>

--- a/app/views/shared/_index_filter_form.html.erb
+++ b/app/views/shared/_index_filter_form.html.erb
@@ -1,15 +1,15 @@
 
 <div class = "d-flex flex-column align-items-center ms-2 position-fixed">
-      <%= form_tag art_pieces_path, method: :get, data: {controller: "indexform"} do %>
+      <%= form_tag art_pieces_path, method: :get, data: {controller: "datefield"} do %>
 
           <%= submit_tag "Show me available art", class: "btn btn-warning text-white mt-3 w-100" %>
           <div class="mt-3">
             Start date
-            <%= date_field_tag :start_date, params[:start_date], class: "form-control", min: Date.today + 1, data: {action: "input->indexform#update", indexform_target: "startDate"} %>
+            <%= date_field_tag :start_date, params[:start_date], class: "form-control", min: Date.today + 1, data: {action: "input->datefield#update", datefield_target: "startDate"} %>
           </div>
           <div class="mt-3">
             End date
-            <%= date_field_tag :end_date, params[:end_date], class: "form-control", min: Date.today + 1, data: { indexform_target: "endDate"}%>
+            <%= date_field_tag :end_date, params[:end_date], class: "form-control", min: Date.today + 1, data: { datefield_target: "endDate"}%>
           </div>
           <div class="mt-3">
             Genres


### PR DESCRIPTION
indexform controller previously udated min date for end date in the form on the index page. 

As the same logic was required for the booking form, I renamed the controller to datefield controller and applied it now to both the date field in the index page and on the booking form. 

**result** : when user selects a start date, the end date is auto updated to minimum of start date. 